### PR TITLE
Remove @ TN if on home page

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
-    <title> {% if page.title %} {{ page.title }} @ {% endif %} TN</title>
+    <title>{% if page.title == 'TRAVIS NEILSON . COM' %}{{ page.title }}{% else %}{% if page.title %} {{ page.title }} @ {% endif %} TN{% endif %}</title>
     <meta name="viewport" content="width=device-width">
     <link rel="stylesheet" href="/assets/css/main.css">
     {% if page.type =="post" %}{{ page.styles }}{% endif %}

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
-    <title>{% if page.title == 'TRAVIS NEILSON . COM' %}{{ page.title }}{% else %}{% if page.title %} {{ page.title }} @ {% endif %} TN{% endif %}</title>
+    <title>{% if page.title == 'TRAVIS NEILSON .COM' %}{{ page.title }}{% else %}{% if page.title %}{{ page.title }} @ {% endif %} TN{% endif %}</title>
     <meta name="viewport" content="width=device-width">
     <link rel="stylesheet" href="/assets/css/main.css">
     {% if page.type =="post" %}{{ page.styles }}{% endif %}

--- a/assets/css/3-sections/_home-notes.sass
+++ b/assets/css/3-sections/_home-notes.sass
@@ -81,7 +81,7 @@ section.notes
         color: #ba9e44
         font-size: 24px
         padding: 0 15px
-
+        -webkit-appearance: none
 
 
     label


### PR DESCRIPTION
This is just personal preference, but I find it redundant to say

> TRAVIS NEILSON .COM @ TN

when you could just say:

> TRAVIS NEILSON .COM
