### PR TITLE
fixed articleTada random number

### DIFF
--- a/assets/js/functions.js
+++ b/assets/js/functions.js
@@ -42,7 +42,7 @@ function designBGStuff() {
 }
 
 function articleTada(){
-  var randNum = Math.floor(Math.random() * $('.article-thumb').length) +1
+  var randNum = Math.floor(Math.random() * $('.article-thumb').length);
   $('.article-thumb').eq(randNum).addClass('is-emph')
     .siblings().removeClass('is-emph');
 }


### PR DESCRIPTION
Hey Travis,

Great series, picked up quite a few tips and tricks so just wanted to say thanks!

I noticed that your `articleTada()` function was generating a random number between 1 and length of `'.article-thumb'`; this would exclude the first element from being called and do nothing if the last number was generated as it would be last index + 1.

This little commit fixes that. 